### PR TITLE
fix: crud-associate

### DIFF
--- a/AsomamecoApi/src/Repository/AssociateRepository.cs
+++ b/AsomamecoApi/src/Repository/AssociateRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using src.Models;
+using src.Utils;
 using System.ComponentModel.DataAnnotations;
 
 namespace src.Repository
@@ -14,13 +15,50 @@ namespace src.Repository
             _context = context;
         }
 
-        // async method to get all Catering Services
-        public async Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize)
+        // async method to get all associates
+        public async Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize, string searchTerm, string orderBy)
         {
             try
             {
-                return await _context.Associate
-                    .OrderBy(a => a.Id)
+                var query = _context.Associate.AsQueryable();
+
+                // if there is a search term, filter the query
+                if (!string.IsNullOrEmpty(searchTerm))
+                    query = query.Where(m => m.Name.Contains(searchTerm) || m.Email.Contains(searchTerm));
+
+                // if there is an orderBy parameter, order the query
+                switch (orderBy)
+                {
+                    case "id":
+                        query = query.OrderBy(m => m.Id);
+                        break;
+                    case "id_desc":
+                        query = query.OrderByDescending(m => m.Id);
+                        break;
+                    case "name":
+                        query = query.OrderBy(m => m.Name);
+                        break;
+                    case "name_desc":
+                        query = query.OrderByDescending(m => m.Name);
+                        break;
+                    case "email":
+                        query = query.OrderBy(m => m.Email);
+                        break;
+                    case "email_desc":
+                        query = query.OrderByDescending(m => m.Email);
+                        break;
+                    case "active":
+                        query = query.OrderBy(m => m.IsActive);
+                        break;
+                    case "active_desc":
+                        query = query.OrderByDescending(m => m.IsActive);
+                        break;
+                    default:
+                        query = query.OrderBy(m => m.Id);
+                        break;
+                }
+
+                return await query
                     .Skip((pageNumber - 1) * pageSize)
                     .Take(pageSize)
                     .Select(a => new Associate
@@ -44,7 +82,7 @@ namespace src.Repository
             }
         }
 
-        public async Task<int> GetCount()
+        public async Task<int> GetCount(string searchTerm)
         {
             try
             {
@@ -110,10 +148,7 @@ namespace src.Repository
                 await _context.Associate.AddAsync(associate);
                 await _context.SaveChangesAsync();
 
-                if (this.GetByID(associate.Id) != null)
-                    return associate;
-                else
-                    throw new Exception("Associate not created");
+                return associate;
             }
             catch (DbUpdateException dbEx)
             {
@@ -173,13 +208,32 @@ namespace src.Repository
 
         }
 
-        public async Task<Associate> Update(Associate associate)
+        public async Task<Associate> Update(int id, Associate associate)
         {
             try
             {
-                _context.Entry(associate).State = EntityState.Modified;
+                //_context.Entry(associate).State = EntityState.Modified;
+                //await _context.SaveChangesAsync();
+                //return associate;
+
+                _context.Associate.Find(id).Name = associate.Name;
+                _context.Associate.Find(id).Email = associate.Email;
+                _context.Associate.Find(id).IsActive = associate.IsActive;
+                _context.Associate.Find(id).IdCard = associate.IdCard;
+                _context.Associate.Find(id).Phone = associate.Phone;
+
                 await _context.SaveChangesAsync();
-                return associate;
+                return await _context.Associate
+                   .Select(a => new Associate
+                   {
+                       Id = a.Id,
+                       Name = a.Name,
+                       Email = a.Email,
+                       Phone = a.Phone,
+                       IsActive = a.IsActive,
+                       IdCard = a.IdCard,
+                   })
+                   .FirstOrDefaultAsync(a => a.Id == id);
             }
             catch (DbUpdateException dbEx)
             {
@@ -191,5 +245,30 @@ namespace src.Repository
             }
         }
 
+        public async Task<Associate> GetByIdCard(string idCard)
+        {
+            try
+            {
+                return await _context.Associate
+                    .Select(a => new Associate
+                    {
+                        Id = a.Id,
+                        Name = a.Name,
+                        Email = a.Email,
+                        Phone = a.Phone,
+                        IsActive = a.IsActive,
+                        IdCard = a.IdCard,
+                    })
+                    .FirstOrDefaultAsync(a => a.IdCard == idCard);
+            }
+            catch (DbUpdateException dbEx)
+            {
+                throw new Exception($"Database error: {dbEx.Message}", dbEx);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"An error occurred: {ex.Message}", ex);
+            }
+        }
     }
 }

--- a/AsomamecoApi/src/Repository/IAssociateRepository.cs
+++ b/AsomamecoApi/src/Repository/IAssociateRepository.cs
@@ -9,12 +9,13 @@ namespace src.Repository
 {
     public interface IAssociateRepository
     {
-        Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize);
-        Task<int> GetCount();
+        Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize, string searchTerm, string orderBy);
+        Task<int> GetCount(string searchTerm);
         Task<Associate> GetByID(int id);
         Task<Associate> GetByEmail(string email);
         Task<Associate> Create(Associate associate);
-        Task<Associate> Update(Associate associate);
+        Task<Associate> GetByIdCard(string idCard);
+        Task<Associate> Update(int id, Associate associate);
         Task<Associate> ChangeState(int id);
         Task<bool> Delete(int id);
     }

--- a/AsomamecoApi/src/Repository/ICateringServiceRepository.cs
+++ b/AsomamecoApi/src/Repository/ICateringServiceRepository.cs
@@ -9,12 +9,12 @@ namespace src.Repository
 {
     public interface ICateringServiceRepository
     {
-        Task<IEnumerable<CateringService>> GetAll(int pageNumber, int pageSize);
-        Task<int> GetCount();
+        Task<IEnumerable<CateringService>> GetAll(int pageNumber, int pageSize, string searchTerm, string orderBy);
+        Task<int> GetCount(string searchTerm);
         Task<CateringService> GetByID(int id);
         Task<CateringService> GetByEmail(string email);
         Task<CateringService> Create(CateringService catering_service);
-        Task<CateringService> Update(CateringService catering_service);
+        Task<CateringService> Update(int id, CateringService catering_service);
         Task<CateringService> ChangeState(int id);
         Task<bool> Delete(int id);
     }

--- a/AsomamecoApi/src/Services/AssociateService.cs
+++ b/AsomamecoApi/src/Services/AssociateService.cs
@@ -12,9 +12,9 @@ namespace src.Services
             _AssociateRepository = AssociateRepository;
         }
 
-        public async Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize)
+        public async Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize, string searchTerm, string orderBy)
         {
-            try { return await _AssociateRepository.GetAll(pageNumber, pageSize).ConfigureAwait(false); }
+            try { return await _AssociateRepository.GetAll(pageNumber, pageSize, searchTerm, orderBy).ConfigureAwait(false); }
             catch (Exception ex)
             {
                 throw new Exception($"An error occurred: {ex.Message}", ex);
@@ -22,9 +22,9 @@ namespace src.Services
             
         }
 
-        public async Task<int> GetCount()
+        public async Task<int> GetCount(string searchTerm)
         {
-            try { return await _AssociateRepository.GetCount().ConfigureAwait(false); }
+            try { return await _AssociateRepository.GetCount(searchTerm).ConfigureAwait(false); }
             catch (Exception ex)
             {
                 throw new Exception($"An error occurred: {ex.Message}", ex);
@@ -57,9 +57,9 @@ namespace src.Services
             }
         }
 
-        public async Task<Associate> Update(Associate associate)
+        public async Task<Associate> Update(int id, Associate associate)
         {
-            try { return await _AssociateRepository.Update(associate); }
+            try { return await _AssociateRepository.Update(id, associate); }
             catch (Exception ex)
             {
                 throw new Exception($"An error occurred: {ex.Message}", ex);
@@ -78,6 +78,15 @@ namespace src.Services
         public async Task<Associate> ChangeState(int id)
         {
             try { return await _AssociateRepository.ChangeState(id); }
+            catch (Exception ex)
+            {
+                throw new Exception($"An error occurred: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<Associate> GetByIdCard(string idCard)
+        {
+            try { return await _AssociateRepository.GetByIdCard(idCard); }
             catch (Exception ex)
             {
                 throw new Exception($"An error occurred: {ex.Message}", ex);

--- a/AsomamecoApi/src/Services/CateringServiceService.cs
+++ b/AsomamecoApi/src/Services/CateringServiceService.cs
@@ -12,9 +12,9 @@ namespace src.Services
             _cateringserviceRepository = cateringserviceRepository;
         }
 
-        public async Task<IEnumerable<CateringService>> GetAll(int pageNumber, int pageSize)
+        public async Task<IEnumerable<CateringService>> GetAll(int pageNumber, int pageSize, string searchTerm, string orderBy)
         {
-            try { return await _cateringserviceRepository.GetAll(pageNumber, pageSize).ConfigureAwait(false); }
+            try { return await _cateringserviceRepository.GetAll(pageNumber, pageSize, searchTerm, orderBy).ConfigureAwait(false); }
             catch (Exception ex)
             {
                 throw new Exception($"An error occurred: {ex.Message}", ex);
@@ -22,9 +22,9 @@ namespace src.Services
             
         }
 
-        public async Task<int> GetCount()
+        public async Task<int> GetCount(string searchTerm)
         {
-            try { return await _cateringserviceRepository.GetCount().ConfigureAwait(false); }
+            try { return await _cateringserviceRepository.GetCount(searchTerm).ConfigureAwait(false); }
             catch (Exception ex)
             {
                 throw new Exception($"An error occurred: {ex.Message}", ex);
@@ -57,9 +57,9 @@ namespace src.Services
             }
         }
 
-        public async Task<CateringService> Update(CateringService catering_service)
+        public async Task<CateringService> Update(int id, CateringService catering_service)
         {
-            try { return await _cateringserviceRepository.Update(catering_service); }
+            try { return await _cateringserviceRepository.Update(id, catering_service); }
             catch (Exception ex)
             {
                 throw new Exception($"An error occurred: {ex.Message}", ex);

--- a/AsomamecoApi/src/Services/IAssociateService.cs
+++ b/AsomamecoApi/src/Services/IAssociateService.cs
@@ -4,12 +4,13 @@ namespace src.Services
 {
     public interface IAssociateService
     {
-        Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize);
-        Task<int> GetCount();
+        Task<IEnumerable<Associate>> GetAll(int pageNumber, int pageSize, string searchTerm, string orderBy);
+        Task<int> GetCount(string searchTerm);
         Task<Associate> GetByID(int id);
+        Task<Associate> GetByIdCard(string idCard);
         Task<Associate> GetByEmail(string email);
         Task<Associate> Create(Associate associate);
-        Task<Associate> Update(Associate associate);
+        Task<Associate> Update(int id, Associate associate);
         Task<Associate> ChangeState(int id);
         Task<bool> Delete(int id);
     }

--- a/AsomamecoApi/src/Services/ICateringServiceService.cs
+++ b/AsomamecoApi/src/Services/ICateringServiceService.cs
@@ -4,12 +4,12 @@ namespace src.Services
 {
     public interface ICateringServiceService
     {
-        Task<IEnumerable<CateringService>> GetAll(int pageNumber, int pageSize);
-        Task<int> GetCount();
+        Task<IEnumerable<CateringService>> GetAll(int pageNumber, int pageSize, string searchTerm, string orderBy);
+        Task<int> GetCount(string searchTerm);
         Task<CateringService> GetByID(int id);
         Task<CateringService> GetByEmail(string email);
         Task<CateringService> Create(CateringService catering_service);
-        Task<CateringService> Update(CateringService catering_service);
+        Task<CateringService> Update(int id, CateringService catering_service);
         Task<CateringService> ChangeState(int id);
         Task<bool> Delete(int id);
     }

--- a/AsomamecoApi/test/Controllers/AssociateControllerTests.cs
+++ b/AsomamecoApi/test/Controllers/AssociateControllerTests.cs
@@ -1,0 +1,378 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using src.Controllers;
+using src.Models;
+using src.Services;
+using src.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace test.Controllers
+{
+    public class AssociatesControllerTests
+    {
+        private readonly IFixture _fixture;
+        private readonly Mock<IAssociateService> _serviceMock;
+        private readonly AssociatesController _controller;
+
+        public AssociatesControllerTests()
+        {
+            _fixture = new Fixture();
+            _serviceMock = _fixture.Freeze<Mock<IAssociateService>>();
+            _controller = new AssociatesController(_serviceMock.Object);
+        }
+
+        // Test Get All
+        [Fact]
+        public async Task GetAll_ShouldReturnOkResponse_WhenDataFound()
+        {
+            // Arrange
+            var AssociatesMock = _fixture.CreateMany<Associate>(50).ToList();
+
+            _serviceMock.Setup(service => service.GetAll(1, 10, null, null)).ReturnsAsync(AssociatesMock);
+
+            // Act
+            var result = await _controller.GetAssociates().ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<ActionResult<PagedResult<Associate>>>();
+            result.Result.Should().BeOfType<OkObjectResult>();
+            result.Result.As<OkObjectResult>().Value
+                .Should()
+                .NotBeNull();
+              
+            _serviceMock.Verify(service => service.GetAll(1, 10, null, null), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAll_ShouldReturnNoContent_WhenNoDataFound()
+        {
+            // Arrange
+            _serviceMock.Setup(service => service.GetAll(1, 10, null, null)).ReturnsAsync((List<Associate>)null);
+
+            // Act
+            var result = await _controller.GetAssociates().ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<NoContentResult>();
+            _serviceMock.Verify(service => service.GetAll(1, 10, null, null), Times.Once);
+        }
+
+
+        [Fact]
+        public async Task GetAll_ShouldReturnInternalServerError_WhenExceptionThrown()
+        {
+            // Arrange
+            _serviceMock.Setup(service => service.GetAll(1, 10, null, null)).ThrowsAsync(new Exception("Some error"));
+
+            // Act
+            var result = await _controller.GetAssociates().ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<ObjectResult>();
+            result.Result.As<ObjectResult>().StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            _serviceMock.Verify(service => service.GetAll(1, 10, null, null), Times.Once);
+        }
+
+        // Test Get By ID
+        [Fact]
+        public async Task GetByID_ShouldReturnOkResponse_WhenValidInput()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+            var id = _fixture.Create<int>();
+            _serviceMock.Setup(service => service.GetByID(id)).ReturnsAsync(AssociateMock);
+
+            // Act
+            var result = await _controller.GetAssociateById(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<ActionResult<Associate>>();
+            result.Result.Should().BeOfType<OkObjectResult>();
+            result.Result.As<OkObjectResult>().Value
+                .Should()
+                .NotBeNull()
+                .And.BeOfType(AssociateMock.GetType());
+            _serviceMock.Verify(service => service.GetByID(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByID_ShouldReturnNoContent_WhenNoDataFound()
+        {
+            // Arrange
+            Associate response = null;
+            var id = _fixture.Create<int>();
+            _serviceMock.Setup(service => service.GetByID(id)).ReturnsAsync(response);
+
+            // Act
+            var result = await _controller.GetAssociateById(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<NoContentResult>();
+            _serviceMock.Verify(service => service.GetByID(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByID_ShouldReturnBadRequest_WhenInputIsZero()
+        {
+            // Arrange
+            var id = 0;
+
+            // Act
+            var result = await _controller.GetAssociateById(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.GetByID(id), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetByID_ShouldReturnBadRequest_WhenInputIsLessThanZero()
+        {
+            // Arrange
+            var id = -1;
+
+            // Act
+            var result = await _controller.GetAssociateById(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.GetByID(id), Times.Never);
+        }
+
+        //test exception
+        [Fact]
+        public async Task GetByID_ShouldReturnInternalServerError_WhenExceptionThrown()
+        {
+            // Arrange
+            var id = _fixture.Create<int>();
+            _serviceMock.Setup(service => service.GetByID(id)).ThrowsAsync(new Exception("Some error"));
+
+            // Act
+            var result = await _controller.GetAssociateById(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<ObjectResult>();
+            result.Result.As<ObjectResult>().StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            _serviceMock.Verify(service => service.GetByID(id), Times.Once);
+        }
+
+        // Test Create
+        [Fact]
+        public async Task Create_ShouldReturnCreatedResponse_WhenValidInput()
+        {
+            // Arrange
+            var request = _fixture.Create<Associate>();
+            var response = _fixture.Create<Associate>();
+            _serviceMock.Setup(service => service.Create(request)).ReturnsAsync(response);
+
+            // Act
+            var result = await _controller.CreateAssociate(request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<ActionResult<Associate>>();
+            result.Result.Should().BeOfType<CreatedAtActionResult>();
+
+            _serviceMock.Verify(service => service.Create(request), Times.Once);    
+        }
+
+        [Fact]
+        public async Task Create_ShouldReturnBadRequest_WhenModelStateIsInvalid()
+        {
+            // Arrange
+            var request = _fixture.Create<Associate>();
+            _controller.ModelState.AddModelError("Name", "Name is required");
+
+            // Act
+            var result = await _controller.CreateAssociate(request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.Create(request), Times.Never);
+        }
+
+        [Fact]
+        public async Task Create_ShouldReturnBadRequest_WhenInputIsNull()
+        {
+            // Arrange
+            Associate request = null;
+
+            // Act
+            var result = await _controller.CreateAssociate(request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.Create(request), Times.Never);
+        }
+
+        [Fact]
+        public async Task Create_ShouldReturnInternalServerError_WhenExceptionThrown()
+        {
+            // Arrange
+            var request = _fixture.Create<Associate>();
+            _serviceMock.Setup(service => service.Create(request)).ThrowsAsync(new Exception("Some error"));
+
+            // Act
+            var result = await _controller.CreateAssociate(request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<ObjectResult>();
+            result.Result.As<ObjectResult>().StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            _serviceMock.Verify(service => service.Create(request), Times.Once);
+        }
+
+        // Test Update
+        [Fact]
+        public async Task Update_ShouldReturnAcceptedAtAction_WhenValidInput()
+        {
+            // Arrange
+            var request = _fixture.Create<Associate>();
+            var response = _fixture.Create<Associate>();
+            _serviceMock.Setup(service => service.Update(request.Id, request)).ReturnsAsync(response);
+
+            // Act
+            var result = await _controller.UpdateAssociate(request.Id, request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<ActionResult<Associate>>();
+            result.Result.Should().BeOfType<AcceptedAtActionResult>();
+
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Once);
+        }
+
+        [Fact]
+        public async Task Update_ShouldReturnBadRequest_WhenModelStateIsInvalid()
+        {
+            // Arrange
+            var request = _fixture.Create<Associate>();
+            _controller.ModelState.AddModelError("Name", "Name is required");
+
+            // Act
+            var result = await _controller.UpdateAssociate(request.Id, request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Never);
+        }
+
+        [Fact]
+        public async Task Update_ShouldReturnBadRequest_WhenInputIsNull()
+        {
+            // Arrange
+            Associate request = null;
+
+            // Act
+            var result = await _controller.UpdateAssociate(1, request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Never);
+        }
+
+        [Fact]
+        public async Task Update_ShouldReturnInternalServerError_WhenExceptionThrown()
+        {
+            // Arrange
+            var request = _fixture.Create<Associate>();
+            _serviceMock.Setup(service => service.Update(request.Id, request)).ThrowsAsync(new Exception("Some error"));
+
+            // Act
+            var result = await _controller.UpdateAssociate(request.Id, request).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<ObjectResult>();
+            result.Result.As<ObjectResult>().StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Once);
+        }
+
+        // Test Change State
+        [Fact]
+        public async Task ChangeState_ShouldReturnAcceptedAtAction_WhenValidInput()
+        {
+            // Arrange
+            var id = _fixture.Create<int>();
+            var response = _fixture.Create<Associate>();
+            _serviceMock.Setup(service => service.ChangeState(id)).ReturnsAsync(response);
+
+            // Act
+            var result = await _controller.ChangeState(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<ActionResult<Associate>>();
+            result.Result.Should().BeOfType<AcceptedAtActionResult>();
+
+            _serviceMock.Verify(service => service.ChangeState(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task ChangeState_ShouldReturnBadRequest_WhenInputIsZero()
+        {
+            // Arrange
+            var id = 0;
+
+            // Act
+            var result = await _controller.ChangeState(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.ChangeState(id), Times.Never);
+        }
+
+        [Fact]
+        public async Task ChangeState_ShouldReturnBadRequest_WhenInputIsLessThanZero()
+        {
+            // Arrange
+            var id = -1;
+
+            // Act
+            var result = await _controller.ChangeState(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+            _serviceMock.Verify(service => service.ChangeState(id), Times.Never);
+        }
+
+        [Fact]
+        public async Task ChangeState_ShouldReturnInternalServerError_WhenExceptionThrown()
+        {
+            // Arrange
+            var id = _fixture.Create<int>();
+            _serviceMock.Setup(service => service.ChangeState(id)).ThrowsAsync(new Exception("Some error"));
+
+            // Act
+            var result = await _controller.ChangeState(id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Result.Should().BeOfType<ObjectResult>();
+            result.Result.As<ObjectResult>().StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            _serviceMock.Verify(service => service.ChangeState(id), Times.Once);
+        }
+
+    }
+}

--- a/AsomamecoApi/test/Controllers/CateringServiceControllerTests.cs
+++ b/AsomamecoApi/test/Controllers/CateringServiceControllerTests.cs
@@ -35,7 +35,7 @@ namespace test.Controllers
             // Arrange
             var cateringserviceMock = _fixture.CreateMany<CateringService>(50).ToList();
 
-            _serviceMock.Setup(service => service.GetAll(1, 10)).ReturnsAsync(cateringserviceMock);
+            _serviceMock.Setup(service => service.GetAll(1, 10,null,null)).ReturnsAsync(cateringserviceMock);
 
             // Act
             var result = await _controller.GetCateringServices().ConfigureAwait(false);
@@ -48,14 +48,14 @@ namespace test.Controllers
                 .Should()
                 .NotBeNull();
               
-            _serviceMock.Verify(service => service.GetAll(1, 10), Times.Once);
+            _serviceMock.Verify(service => service.GetAll(1, 10, null, null), Times.Once);
         }
 
         [Fact]
         public async Task GetAll_ShouldReturnNoContent_WhenNoDataFound()
         {
             // Arrange
-            _serviceMock.Setup(service => service.GetAll(1, 10)).ReturnsAsync((List<CateringService>)null);
+            _serviceMock.Setup(service => service.GetAll(1, 10, null, null)).ReturnsAsync((List<CateringService>)null);
 
             // Act
             var result = await _controller.GetCateringServices().ConfigureAwait(false);
@@ -63,7 +63,7 @@ namespace test.Controllers
             // Assert
             result.Should().NotBeNull();
             result.Result.Should().BeOfType<NoContentResult>();
-            _serviceMock.Verify(service => service.GetAll(1, 10), Times.Once);
+            _serviceMock.Verify(service => service.GetAll(1, 10, null, null), Times.Once);
         }
 
 
@@ -71,7 +71,7 @@ namespace test.Controllers
         public async Task GetAll_ShouldReturnInternalServerError_WhenExceptionThrown()
         {
             // Arrange
-            _serviceMock.Setup(service => service.GetAll(1, 10)).ThrowsAsync(new Exception("Some error"));
+            _serviceMock.Setup(service => service.GetAll(1, 10, null, null)).ThrowsAsync(new Exception("Some error"));
 
             // Act
             var result = await _controller.GetCateringServices().ConfigureAwait(false);
@@ -80,7 +80,7 @@ namespace test.Controllers
             result.Should().NotBeNull();
             result.Result.Should().BeOfType<ObjectResult>();
             result.Result.As<ObjectResult>().StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            _serviceMock.Verify(service => service.GetAll(1, 10), Times.Once);
+            _serviceMock.Verify(service => service.GetAll(1, 10, null, null), Times.Once);
         }
 
         // Test Get By ID
@@ -246,17 +246,17 @@ namespace test.Controllers
             // Arrange
             var request = _fixture.Create<CateringService>();
             var response = _fixture.Create<CateringService>();
-            _serviceMock.Setup(service => service.Update(request)).ReturnsAsync(response);
+            _serviceMock.Setup(service => service.Update(request.Id, request)).ReturnsAsync(response);
 
             // Act
-            var result = await _controller.UpdateCateringService(request).ConfigureAwait(false);
+            var result = await _controller.UpdateCateringService(request.Id, request).ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
             result.Should().BeAssignableTo<ActionResult<CateringService>>();
             result.Result.Should().BeOfType<AcceptedAtActionResult>();
 
-            _serviceMock.Verify(service => service.Update(request), Times.Once);
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Once);
         }
 
         [Fact]
@@ -267,12 +267,12 @@ namespace test.Controllers
             _controller.ModelState.AddModelError("Name", "Name is required");
 
             // Act
-            var result = await _controller.UpdateCateringService(request).ConfigureAwait(false);
+            var result = await _controller.UpdateCateringService(request.Id, request).ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
             result.Result.Should().BeOfType<BadRequestObjectResult>();
-            _serviceMock.Verify(service => service.Update(request), Times.Never);
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Never);
         }
 
         [Fact]
@@ -282,12 +282,12 @@ namespace test.Controllers
             CateringService request = null;
 
             // Act
-            var result = await _controller.UpdateCateringService(request).ConfigureAwait(false);
+            var result = await _controller.UpdateCateringService(request.Id, request).ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
             result.Result.Should().BeOfType<BadRequestObjectResult>();
-            _serviceMock.Verify(service => service.Update(request), Times.Never);
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Never);
         }
 
         [Fact]
@@ -295,16 +295,16 @@ namespace test.Controllers
         {
             // Arrange
             var request = _fixture.Create<CateringService>();
-            _serviceMock.Setup(service => service.Update(request)).ThrowsAsync(new Exception("Some error"));
+            _serviceMock.Setup(service => service.Update(request.Id, request)).ThrowsAsync(new Exception("Some error"));
 
             // Act
-            var result = await _controller.UpdateCateringService(request).ConfigureAwait(false);
+            var result = await _controller.UpdateCateringService(request.Id, request).ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
             result.Result.Should().BeOfType<ObjectResult>();
             result.Result.As<ObjectResult>().StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            _serviceMock.Verify(service => service.Update(request), Times.Once);
+            _serviceMock.Verify(service => service.Update(request.Id, request), Times.Once);
         }
 
         // Test Change State

--- a/AsomamecoApi/test/Services/AssociateServiceTests.cs
+++ b/AsomamecoApi/test/Services/AssociateServiceTests.cs
@@ -1,0 +1,286 @@
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using src.Models;
+using src.Repository;
+using src.Services;
+using src.Utils;
+
+namespace test.Services
+{
+    public class AssociateServiceTests
+    {
+        private readonly IFixture _fixture;
+        private readonly IAssociateService _service;
+        private readonly Mock<IAssociateRepository> _repositoryMock;
+
+        public AssociateServiceTests()
+        {
+            _fixture = new Fixture();
+            _repositoryMock = _fixture.Freeze<Mock<IAssociateRepository>>();
+            _service = new AssociateService(_repositoryMock.Object);
+        }
+
+        // Test Get All
+        [Fact]
+        public async Task GetAll_ShouldReturnData_WhenDataFound()
+        {
+            // Arrange
+            var AssociatesMock = _fixture.CreateMany<Associate>(50).ToList();
+
+            _repositoryMock.Setup(repo => repo.GetAll(1, 10, null, null)).ReturnsAsync(AssociatesMock);
+
+            // Act
+            var result = await _service.GetAll(1, 10, null, null).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<IEnumerable<Associate>>();
+            result.Should().BeEquivalentTo(AssociatesMock);
+            _repositoryMock.Verify(repo => repo.GetAll(1, 10, null, null), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAll_ShouldReturnEmpty_WhenNoDataFound()
+        {
+            // Arrange
+            _repositoryMock.Setup(repo => repo.GetAll(1, 10, null, null)).ReturnsAsync(Enumerable.Empty<Associate>());
+
+            // Act
+            var result = await _service.GetAll(1, 10, null, null).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<IEnumerable<Associate>>();
+            result.Should().BeEmpty();
+            _repositoryMock.Verify(repo => repo.GetAll(1, 10, null, null), Times.Once);
+        }
+
+        // Test Get Total
+        [Fact]
+        public async Task GetTotal_ShouldReturnData_WhenDataFound()
+        {
+            // Arrange
+            var AssociatesMock = _fixture.CreateMany<Associate>(50).ToList();
+
+            _repositoryMock.Setup(repo => repo.GetCount(null)).ReturnsAsync(AssociatesMock.Count);
+
+            // Act
+            var result = await _service.GetCount(null).ConfigureAwait(false);
+
+            // Assert
+            result.Should().Be(50); // 50
+            _repositoryMock.Verify(repo => repo.GetCount(null), Times.Once);
+        }
+
+        // Test Get By Email
+        [Fact]
+        public async Task GetByEmail_ShouldReturnData_WhenDataFound()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.GetByEmail(AssociateMock.Email)).ReturnsAsync(AssociateMock);
+
+            // Act
+            var result = await _service.GetByEmail(AssociateMock.Email).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<Associate>();
+            result.Should().BeEquivalentTo(AssociateMock);
+            _repositoryMock.Verify(repo => repo.GetByEmail(AssociateMock.Email), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByEmail_ShouldReturnNull_WhenNoDataFound()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.GetByEmail(AssociateMock.Email)).ReturnsAsync((Associate)null);
+
+            // Act
+            var result = await _service.GetByEmail(AssociateMock.Email).ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeNull();
+            _repositoryMock.Verify(repo => repo.GetByEmail(AssociateMock.Email), Times.Once);
+        }
+
+        // Test Get By ID
+        [Fact]
+        public async Task GetByID_ShouldReturnData_WhenDataFound()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.GetByID(AssociateMock.Id)).ReturnsAsync(AssociateMock);
+
+            // Act
+            var result = await _service.GetByID(AssociateMock.Id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<Associate>();
+            result.Should().BeEquivalentTo(AssociateMock);
+            _repositoryMock.Verify(repo => repo.GetByID(AssociateMock.Id), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByID_ShouldReturnNull_WhenNoDataFound()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.GetByID(AssociateMock.Id)).ReturnsAsync((Associate)null);
+
+            // Act
+            var result = await _service.GetByID(AssociateMock.Id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeNull();
+            _repositoryMock.Verify(repo => repo.GetByID(AssociateMock.Id), Times.Once);
+        }
+
+        // Test Create
+        [Fact]
+        public async Task Create_ShouldReturnData_WhenDataCreated()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.Create(AssociateMock)).ReturnsAsync(AssociateMock);
+
+            // Act
+            var result = await _service.Create(AssociateMock).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<Associate>();
+            result.Should().BeEquivalentTo(AssociateMock);
+            _repositoryMock.Verify(repo => repo.Create(AssociateMock), Times.Once);
+        }
+
+        [Fact]
+        public async Task Create_ShouldReturnNull_WhenDataNotCreated()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.Create(AssociateMock)).ReturnsAsync((Associate)null);
+
+            // Act
+            var result = await _service.Create(AssociateMock).ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeNull();
+            _repositoryMock.Verify(repo => repo.Create(AssociateMock), Times.Once);
+        }
+
+        // Test Delete 
+        [Fact]
+        public async Task Delete_ShouldReturnTrue_WhenDataDeleted()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+            _repositoryMock.Setup(repo => repo.Delete(AssociateMock.Id)).ReturnsAsync(true);
+
+            // Act
+            var result = await _service.Delete(AssociateMock.Id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeTrue();
+            _repositoryMock.Verify(repo => repo.Delete(AssociateMock.Id), Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete_ShouldReturnFalse_WhenDataNotDeleted()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.Delete(AssociateMock.Id)).ReturnsAsync(false);
+
+            // Act
+            var result = await _service.Delete(AssociateMock.Id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeFalse();
+            _repositoryMock.Verify(repo => repo.Delete(AssociateMock.Id), Times.Once);
+        }
+
+        // Test Update
+        [Fact]
+        public async Task Update_ShouldReturnUpdatedData_WhenDataUpdated()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+            var response = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.Update(AssociateMock.Id, AssociateMock)).ReturnsAsync(response);
+
+            // Act
+            var result = await _service.Update(AssociateMock.Id, AssociateMock).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<Associate>();
+            result.Should().BeEquivalentTo(response);
+            _repositoryMock.Verify(repo => repo.Update(AssociateMock.Id, AssociateMock), Times.Once);
+        }
+
+        [Fact]
+        public async Task Update_ShouldReturnNull_WhenDataNotUpdated()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.Update(AssociateMock.Id, AssociateMock)).ReturnsAsync((Associate)null);
+
+            // Act
+            var result = await _service.Update(AssociateMock.Id, AssociateMock).ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeNull();
+            _repositoryMock.Verify(repo => repo.Update(AssociateMock.Id, AssociateMock), Times.Once);
+        }
+
+        // Test Change State
+        [Fact]
+        public async Task ChangeState_ShouldReturnUpdatedData_WhenDataUpdated()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+            var response = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.ChangeState(AssociateMock.Id)).ReturnsAsync(response);
+
+            // Act
+            var result = await _service.ChangeState(AssociateMock.Id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<Associate>();
+            // response.IsActive should be different from AssociateMock.IsActive
+            result.IsActive.Should().NotBe(AssociateMock.IsActive);
+            _repositoryMock.Verify(repo => repo.ChangeState(AssociateMock.Id), Times.Once);
+        }
+
+        [Fact]
+        public async Task ChangeState_ShouldReturnNull_WhenDataNotUpdated()
+        {
+            // Arrange
+            var AssociateMock = _fixture.Create<Associate>();
+
+            _repositoryMock.Setup(repo => repo.ChangeState(AssociateMock.Id)).ReturnsAsync((Associate)null);
+
+            // Act
+            var result = await _service.ChangeState(AssociateMock.Id).ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeNull();
+            _repositoryMock.Verify(repo => repo.ChangeState(AssociateMock.Id), Times.Once);
+        }
+    }
+}

--- a/AsomamecoApi/test/Services/CateringServiceServiceTests.cs
+++ b/AsomamecoApi/test/Services/CateringServiceServiceTests.cs
@@ -28,32 +28,32 @@ namespace test.Services
             // Arrange
             var cateringserviceMock = _fixture.CreateMany<CateringService>(50).ToList();
 
-            _repositoryMock.Setup(repo => repo.GetAll(1, 10)).ReturnsAsync(cateringserviceMock);
+            _repositoryMock.Setup(repo => repo.GetAll(1, 10, null, null)).ReturnsAsync(cateringserviceMock);
 
             // Act
-            var result = await _service.GetAll(1, 10).ConfigureAwait(false);
+            var result = await _service.GetAll(1, 10,null, null).ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
             result.Should().BeAssignableTo<IEnumerable<CateringService>>();
             result.Should().BeEquivalentTo(cateringserviceMock);
-            _repositoryMock.Verify(repo => repo.GetAll(1, 10), Times.Once);
+            _repositoryMock.Verify(repo => repo.GetAll(1, 10,null,null), Times.Once);
         }
 
         [Fact]
         public async Task GetAll_ShouldReturnEmpty_WhenNoDataFound()
         {
             // Arrange
-            _repositoryMock.Setup(repo => repo.GetAll(1, 10)).ReturnsAsync(Enumerable.Empty<CateringService>());
+            _repositoryMock.Setup(repo => repo.GetAll(1, 10,null,null)).ReturnsAsync(Enumerable.Empty<CateringService>());
 
             // Act
-            var result = await _service.GetAll(1, 10).ConfigureAwait(false);
+            var result = await _service.GetAll(1, 10, null, null).ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
             result.Should().BeAssignableTo<IEnumerable<CateringService>>();
             result.Should().BeEmpty();
-            _repositoryMock.Verify(repo => repo.GetAll(1, 10), Times.Once);
+            _repositoryMock.Verify(repo => repo.GetAll(1, 10, null, null), Times.Once);
         }
 
         // Test Get Total
@@ -63,14 +63,14 @@ namespace test.Services
             // Arrange
             var cateringserviceMock = _fixture.CreateMany<CateringService>(50).ToList();
 
-            _repositoryMock.Setup(repo => repo.GetCount()).ReturnsAsync(cateringserviceMock.Count);
+            _repositoryMock.Setup(repo => repo.GetCount(null)).ReturnsAsync(cateringserviceMock.Count);
 
             // Act
-            var result = await _service.GetCount().ConfigureAwait(false);
+            var result = await _service.GetCount(null).ConfigureAwait(false);
 
             // Assert
             result.Should().Be(50); // 50
-            _repositoryMock.Verify(repo => repo.GetCount(), Times.Once);
+            _repositoryMock.Verify(repo => repo.GetCount(null), Times.Once);
         }
 
         // Test Get By Email
@@ -218,16 +218,16 @@ namespace test.Services
             var cateringserviceMock = _fixture.Create<CateringService>();
             var response = _fixture.Create<CateringService>();
 
-            _repositoryMock.Setup(repo => repo.Update(cateringserviceMock)).ReturnsAsync(response);
+            _repositoryMock.Setup(repo => repo.Update(cateringserviceMock.Id, cateringserviceMock)).ReturnsAsync(response);
 
             // Act
-            var result = await _service.Update(cateringserviceMock).ConfigureAwait(false);
+            var result = await _service.Update(cateringserviceMock.Id, cateringserviceMock).ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
             result.Should().BeAssignableTo<CateringService>();
             result.Should().BeEquivalentTo(response);
-            _repositoryMock.Verify(repo => repo.Update(cateringserviceMock), Times.Once);
+            _repositoryMock.Verify(repo => repo.Update(cateringserviceMock.Id, cateringserviceMock), Times.Once);
         }
 
         [Fact]
@@ -236,14 +236,14 @@ namespace test.Services
             // Arrange
             var cateringserviceMock = _fixture.Create<CateringService>();
 
-            _repositoryMock.Setup(repo => repo.Update(cateringserviceMock)).ReturnsAsync((CateringService)null);
+            _repositoryMock.Setup(repo => repo.Update(cateringserviceMock.Id, cateringserviceMock)).ReturnsAsync((CateringService)null);
 
             // Act
-            var result = await _service.Update(cateringserviceMock).ConfigureAwait(false);
+            var result = await _service.Update(cateringserviceMock.Id, cateringserviceMock).ConfigureAwait(false);
 
             // Assert
             result.Should().BeNull();
-            _repositoryMock.Verify(repo => repo.Update(cateringserviceMock), Times.Once);
+            _repositoryMock.Verify(repo => repo.Update(cateringserviceMock.Id, cateringserviceMock), Times.Once);
         }
 
         // Test Change State

--- a/AsomamecoApi/test/Services/MemberServiceTests.cs
+++ b/AsomamecoApi/test/Services/MemberServiceTests.cs
@@ -63,14 +63,14 @@ namespace test.Services
             // Arrange
             var membersMock = _fixture.CreateMany<Member>(50).ToList();
 
-            _repositoryMock.Setup(repo => repo.GetCount()).ReturnsAsync(membersMock.Count);
+            _repositoryMock.Setup(repo => repo.GetCount(null)).ReturnsAsync(membersMock.Count);
 
             // Act
-            var result = await _service.GetCount().ConfigureAwait(false);
+            var result = await _service.GetCount(null).ConfigureAwait(false);
 
             // Assert
             result.Should().Be(50); // 50
-            _repositoryMock.Verify(repo => repo.GetCount(), Times.Once);
+            _repositoryMock.Verify(repo => repo.GetCount(null), Times.Once);
         }
 
         // Test Get By Email


### PR DESCRIPTION
Cambios en el Crud de Associate: 
- Los update reciben el id como parametro
- ⁠Los métodos de Update y Create verifican que no haya campos repetidos
- ⁠El método de GetAll recibe SearchTerm y OrderBy
- ⁠El método de GetCount para la paginación reciben un parametro de SearchTerm

Además, se crearon los archivos de testing que hacían falta. Había un problema con el MemberServiceTests, que en el método GetCount no enviaba parámetro, pero ya lo arreglé. El método Update_ShouldReturnBadRequest_WhenInputIsNull aún no pasa el testing, desconozco la razón, favor revisar.

PD: No hice una branch porque este crud fue realizado directamente al Back.